### PR TITLE
Add projectability disentanglement to wannierize.py

### DIFF
--- a/src/symwannier/wannierize.py
+++ b/src/symwannier/wannierize.py
@@ -10,11 +10,13 @@
 
 import numpy as np
 import scipy.linalg
+import scipy.optimize
 import itertools
 import textwrap
 import datetime
 import argparse
 import sys
+import logging
 
 from symwannier.win import Win
 from symwannier.mmn import Mmn
@@ -25,32 +27,73 @@ from symwannier.nnkp import Nnkp
 from symwannier.timedata import TimeData
 
 class Wannierize:
-    def __init__(self, prefix, lsym=False, lsite_sym=False, prec=False):
-        self.time = TimeData()
-        self.win = Win(prefix)
-        self.nnkp = Nnkp(prefix + ".nnkp")
+    """Compute maximally localized (and symmetry-adapted) Wannier functions.
+
+    Parameters
+    ----------
+    prefix : str
+        Prefix for input/output files (e.g., ``prefix.win``, ``prefix.mmn``).
+    lsym : bool, optional
+        Use symmetry-aware inputs (``*.isym``, ``*.immn``, ``*.iamn``, ``*.ieig``).
+    lsite_sym : bool, optional
+        Apply site symmetry after Wannierization (implies ``lsym=True``).
+    prec : bool, optional
+        If True, write high-precision outputs for hr.dat / tb.dat.
+    optimize_memory_usage : bool, optional
+        If True, prioritize memory efficiency over speed (default: False).
+        If False (default), prioritize speed (may use more memory). 
+    projectability_disentangle : bool, optional
+        If True, build disentanglement windows from AMN projectability instead of energy windows.
+    log_level : int or str, optional
+        Logging level (e.g., logging.DEBUG, logging.INFO, or 'DEBUG', 'INFO').
+    log : logging.Logger, optional
+        Logger to use; if not provided a module logger is created.
+    """
+
+    def __init__(self, prefix, lsym=False, lsite_sym=False, prec=False, optimize_memory_usage=False, projectability_disentangle=False, log_level=None, log=None):
+        self.log = log or logging.getLogger(__name__)
+        if not self.log.handlers:
+            # Determine log level
+            if log_level is None:
+                level = logging.INFO
+            elif isinstance(log_level, str):
+                level = getattr(logging, log_level.upper(), logging.INFO)
+            else:
+                level = log_level
+            logging.basicConfig(level=level, format="%(message)s")
+        self.log.debug(f"Initializing Wannierize with prefix={prefix}, lsym={lsym}, lsite_sym={lsite_sym}")
+        self.prefix = prefix
+        self.time = TimeData(log=self.log)
+        self.win = Win(prefix, log=self.log)
+        self.log.debug(f"Loaded win: num_wann={self.win.num_wann}")
+        self.nnkp = Nnkp(prefix + ".nnkp", log=self.log)
+        self.log.debug(f"Loaded nnkp: nk={self.nnkp.nk}, nb={self.nnkp.nb}")
         self.lsym = lsym
         self.lsite_sym = lsite_sym
         self.prec = prec
+        self.optimize_memory_usage = optimize_memory_usage
+        self.projectability_disentangle = projectability_disentangle
         if self.lsite_sym:
             self.lsym = True
 
         if self.lsym:
             self.time.start_clock("sym read")
-            self.sym = Sym(file_sym=prefix + ".isym", nnkp=self.nnkp)
+            self.sym = Sym(file_sym=prefix + ".isym", nnkp=self.nnkp, log=self.log)
             self.time.stop_clock("sym read")
+            self.log.debug(f"Loaded symmetry: nsym={len(self.sym.s)}")
             ext = 'i'
         else:
             self.sym = None
             ext = ''
 
         self.time.start_clock("mmn read")
-        mmn = Mmn(file_mmn = prefix+"." + ext + "mmn", nnkp=self.nnkp, sym=self.sym)
+        mmn = Mmn(file_mmn = prefix+"." + ext + "mmn", nnkp=self.nnkp, sym=self.sym, log=self.log)
         self.time.stop_clock("mmn read")
+        self.log.debug(f"Loaded Mmn: shape={mmn.mmn.shape}")
 
         self.mmn0 = mmn.mmn
         self.num_bands = mmn.num_bands
-        self.num_wann = self.nnkp.num_wann
+        self.num_wann = self.win.num_wann
         self.nk = self.nnkp.nk
         self.kpts = self.nnkp.kpoints
         self.nb = self.nnkp.nb
@@ -59,9 +102,28 @@ class Wannierize:
         self.kb2k = mmn.kb2k   # index of k+b
 
         self.time.start_clock("amn read")
-        self.amn = Amn(prefix+"." + ext + "amn", nnkp=self.nnkp, sym=self.sym)
+        self.amn = Amn(prefix+"." + ext + "amn", nnkp=self.nnkp, sym=self.sym, log=self.log)
         self.time.stop_clock("amn read")
-        self.eig = Eig(prefix+"." + ext + "eig", sym=self.sym)
+        self.eig = Eig(prefix+"." + ext + "eig", sym=self.sym, log=self.log)
+        self.log.debug(f"Loaded Amn: shape={self.amn.amn.shape}, Eig: shape={self.eig.eig.shape}")
+        # Projectability p_mk = sum_n |<psi_mk|g_n>|^2 for optional disentanglement mode
+        self.projectability = np.einsum(
+            "knm,knm->kn", self.amn.amn, np.conj(self.amn.amn), optimize=True
+        ).real
+        is_finite = np.isfinite(self.projectability)
+        num_nan = np.isnan(self.projectability).sum()
+        num_inf = np.isinf(self.projectability).sum()
+        num_neg = (self.projectability < 0).sum()
+        self.log.info(
+            "projectability stats: "
+            f"min={np.min(self.projectability):.6e}, max={np.max(self.projectability):.6e}, "
+            f"nan={num_nan}, inf={num_inf}, neg={num_neg}"
+        )
+        if not is_finite.all():
+            raise ValueError("projectability contains NaN or inf")
+        if num_neg != 0:
+            raise ValueError("projectability contains negative values")
+        self._validate_inputs()
         self.Umat_opt = None
 
         self.file_hr_dat = prefix + "_py_hr.dat"
@@ -76,9 +138,13 @@ class Wannierize:
         """
         main subroutine
         """
+        self.log.info("Starting wannierization for prefix '%s' (lsym=%s, lsite_sym=%s)", self.prefix, self.lsym, self.lsite_sym)
         # disentanglement. minimize omega_I
         if self.disentangle:
-            self.dis_window()
+            if self.projectability_disentangle:
+                self.dis_window_projectability()
+            else:
+                self.dis_window()
             self.dis_project()
             self.dis_extract()
 
@@ -92,26 +158,31 @@ class Wannierize:
         """
         wannierization procedure
         """
+        self.log.debug("Starting wannierization loop")
         self.init_Umat_and_Mmn()
 
         omega = self.calc_omega(self.mmn)
+        self.log.debug(f"Initial omega_tot = {omega:.8f}")
         print("! Initial:  omega_tot = {:15.8f}    time: {:12.6f}".format(omega, self.time.get_time()))
         self.show_spreads()
         converged = False
+        self.time.start_clock("wannierization")
         for i in range(self.win.num_iter):
-            self.time.start_clock("wannierization")
+            self.log.debug(f"Wannierization iteration {i+1}/{self.win.num_iter}")
             omega_prev = omega
             dw = self.calc_dw()
             omega = self.update_mmn(dw, omega)
+            self.log.debug(f"Iteration {i+1}: omega_tot = {omega:.8f}, delta_omega = {abs(omega - omega_prev):.2e}")
             print("! {:5d}-th  omega_tot = {:15.8f}    time: {:12.6f}".format(i+1, omega, self.time.get_time()))
             self.show_spreads()
             self.calc_omega_detail(self.mmn)
 
             converged = np.abs(omega - omega_prev) < self.omega_thr
             if converged:
+                self.log.debug("Wannierization converged")
                 print("  convergence has been achieved")
                 break
-            self.time.stop_clock("wannierization")
+        self.time.stop_clock("wannierization")
         print("! Final:    omega_tot = {:15.8f}    time: {:12.6f}".format(omega, self.time.get_time()))
 
     def post_process(self):
@@ -130,33 +201,68 @@ class Wannierize:
         self.write_tb()
         self.time.show_all()
 
+    def _validate_inputs(self):
+        """Validate basic consistency of loaded inputs to fail fast with clear errors."""
+        self.log.debug(f"Validating inputs: num_wann={self.num_wann}, num_bands={self.num_bands}, nk={self.nnkp.nk}, nb={self.nnkp.nb}")
+        if self.num_wann > self.num_bands:
+            raise ValueError("num_wann ({}) must not exceed num_bands ({})".format(self.num_wann, self.num_bands))
+
+        if self.mmn0.shape[0] != self.nnkp.nk or self.mmn0.shape[1] != self.nnkp.nb:
+            raise ValueError("mmn shape {} inconsistent with nk={} or nb={}".format(self.mmn0.shape, self.nnkp.nk, self.nnkp.nb))
+
+        if getattr(self.amn, "nk", None) and self.amn.nk != self.nnkp.nk:
+            raise ValueError("amn nk={} inconsistent with nnkp nk={}".format(self.amn.nk, self.nnkp.nk))
+
+        if getattr(self.eig, "nk", None) and self.eig.nk != self.nnkp.nk:
+            raise ValueError("eig nk={} inconsistent with nnkp nk={}".format(self.eig.nk, self.nnkp.nk))
+
     def show_spreads(self):
+        """Print Wannier function centers and spreads in Cartesian coordinates."""
         print("{:>8s},{:>46s},{:>16s}".format("WF num", "center in cartesian coords", "spread (A^2)"))
         for nw in range(self.num_wann):
             print("  {0:6d}   ( {1[0]:12.6f}, {1[1]:12.6f}, {1[2]:12.6f} )  {2:15.8f}".format(nw+1, self.r[nw].real, self.spreads[nw].real))
 
     def update_Mmn_by_Umat(self, mmn, Umat):
+        """Transform overlap matrix Mmn by unitary rotation.
+        
+        Computes Mmn = U^k Mmn^(0) U^(k+b) following R1_Eq.(61).
+        Uses either global pre-compute (fast, memory-heavy) or batched k-loop (balanced).
+        
+        Parameters
+        ----------
+        mmn : ndarray, shape (nk, nb, num_bands, num_bands)
+            Overlap matrices between neighboring k-points.
+        Umat : ndarray, shape (nk, num_bands, num_wann)
+            Unitary rotation matrices at each k-point.
+        
+        Returns
+        -------
+        ndarray, shape (nk, nb, num_wann, num_wann)
+            Rotated overlap matrices.
         """
-        return Mmn = U^k Mmn^(0) U^(k+b)
-        """
-        #for k in range(self.nk):
-        #    assert np.allclose( np.matmul(Umat[:,:,k], np.transpose(np.conj(Umat[:,:,k]))), np.eye(self.num_bands) ), "Umat is not unitary for k = {}".format(k)
-        return np.einsum("klm, kblp, kbpn->kbmn", np.conj(Umat), mmn, Umat[self.kb2k[:,:],:,:], optimize=True) # Eq. (61)
+        if not self.optimize_memory_usage:
+            # Pre-compute indexed Umat for all k+b pairs to avoid repeated indexing
+            Umat_kpb = Umat[self.kb2k.ravel()].reshape(self.nk, self.nb, Umat.shape[1], Umat.shape[2])
+            return np.einsum("klm, kblp, kbpn->kbmn", np.conj(Umat), mmn, Umat_kpb, optimize=True)
+        else:
+            # Memory-efficient: re-index on each call (no pre-computation)
+            return np.einsum("klm, kblp, kbpn->kbmn", np.conj(Umat), mmn, Umat[self.kb2k[:,:],:,:], optimize=True)
 
     def init_Umat_and_Mmn(self):
         """
         initialize self.Umat (U^k) and calculate self.mmn (Mmn = U^k Mmn^(0) U^k+b)
         Mmn0 (input) -> Mmn1 (disentangle) -> Mmn
         """
+        self.log.debug(f"init_Umat_and_Mmn: disentangle={self.disentangle}")
         if self.disentangle:
-            print("  init Umatrix and Mmn using Umatrix_opt")
+            self.log.info("init Umatrix and Mmn using Umatrix_opt")
             self.Umat = self.amn.Umat(index_win=self.index_win, Umat_opt=self.Umat_opt)
             self.mmn1 = self.update_Mmn_by_Umat(self.mmn0, self.Umat_opt)
             self.mmn = self.update_Mmn_by_Umat(self.mmn1, self.Umat)
             self.calc_omega_detail(self.mmn)
 
         else:  # without disentangle
-            print("  init Umatrix and Mmn")
+            self.log.info("init Umatrix and Mmn")
             if hasattr(self, "amn"):
                 self.Umat = self.amn.Umat()
                 self.mmn1 = self.mmn0
@@ -170,28 +276,48 @@ class Wannierize:
                 self.mmn = self.mmn1
 
     def calc_omega(self, mmn):
-        """
-        calculate Omega = sum <r^2> - <r>^2
-        update self.r (<r>)
-        """
-        #r = 1j/self.nk * np.einsum("b,ba,nnkb->na", self.wb, self.bvec, self.mmn, optimize=True)
-        #r -= 1j * np.einsum("b,ba->a", self.wb, self.bvec)
-        #print("r = ", r)
-        mnn = np.einsum("kbnn->kbn", mmn, optimize=True)
-        imlnmnn = np.log(mnn).imag
-        r = -1/self.nk * np.einsum("b,ba,kbn->na", self.wb, self.bvec, imlnmnn, optimize=True)
-
-        r2a = np.sum(self.wb)*self.nk - np.einsum("b,kbn,kbn->n", self.wb, mnn, np.conj(mnn), optimize=True)
-        r2b = np.einsum("b,kbn->n", self.wb, imlnmnn**2)
-        r2 = 1/self.nk * (r2a + r2b).real
-        self.r = r
+        """Calculate total spread functional Omega.
         
-        self.spreads = r2 - np.sum(r[:,:].real**2, axis=1)
+        Computes Omega = sum_n [<r^2>_n - <r>_n^2] following R1_Eqs.(11,31,32).
+        Updates self.r (Wannier function centers) and self.spreads as side effects.
+        Caches mnn and imlnmnn for reuse in calc_omega_detail.
+        
+        Parameters
+        ----------
+        mmn : ndarray, shape (nk, nb, num_wann, num_wann)
+            Overlap matrices M^(k,b)_mn.
+        
+        Returns
+        -------
+        float
+            Total spread Omega (sum of individual spreads).
+        """
+        self.log.debug(f"calc_omega: mmn.shape={mmn.shape}")
+        # Cache for reuse in calc_omega_detail and calc_dw
+        self._cached_mnn = np.einsum("kbnn->kbn", mmn, optimize=True)
+        self._assert_nonzero_mnn(self._cached_mnn, "calc_omega")
+        self._cached_imlnmnn = np.log(self._cached_mnn).imag
+        self._cached_r = -1/self.nk * np.einsum("b,ba,kbn->na", self.wb, self.bvec, self._cached_imlnmnn, optimize=True)
+        
+        r2a = np.sum(self.wb)*self.nk - np.einsum("b,kbn,kbn->n", self.wb, self._cached_mnn, np.conj(self._cached_mnn), optimize=True)
+        r2b = np.einsum("b,kbn->n", self.wb, self._cached_imlnmnn**2)
+        r2 = 1/self.nk * (r2a + r2b).real
+        self.r = self._cached_r
+        
+        self.spreads = r2 - np.sum(self.r[:,:].real**2, axis=1)
         return np.sum(self.spreads)
 
     def calc_omega_detail(self, mmn):
-        """
-        calculate OmegaI, Omega_D, Omega_OD
+        """Decompose spread into gauge-invariant (I), diagonal (D), and off-diagonal (OD) parts.
+        
+        Following R1_Eq.(13,18), Omega = OmegaI + OmegaD + OmegaOD.
+        Prints the three components to stdout.
+        Reuses cached mnn and imlnmnn from calc_omega if available.
+        
+        Parameters
+        ----------
+        mmn : ndarray, shape (nk, nb, num_wann, num_wann)
+            Overlap matrices M^(k,b)_mn.
         """
         mmn2 = np.einsum("kbmn,kbmn->kb", mmn, np.conj(mmn), optimize=True).real
         OmegaI = np.einsum("b, kb->", self.wb, self.num_wann - mmn2, optimize=True)/self.nk
@@ -199,8 +325,15 @@ class Wannierize:
         mnn2 = np.einsum("kbnn,kbnn->kb", mmn, np.conj(mmn), optimize=True).real
         OmegaOD = np.einsum("b, kb->", self.wb, mmn2 - mnn2, optimize=True)/self.nk
 
-        mnn = np.einsum("kbnn->kbn", mmn, optimize=True)
-        imlnmnn = np.log(mnn).imag
+        # Reuse cached values if available (set by calc_omega)
+        if hasattr(self, '_cached_mnn') and hasattr(self, '_cached_imlnmnn'):
+            mnn = self._cached_mnn
+            imlnmnn = self._cached_imlnmnn
+        else:
+            mnn = np.einsum("kbnn->kbn", mmn, optimize=True)
+            self._assert_nonzero_mnn(mnn, "calc_omega_detail")
+            imlnmnn = np.log(mnn).imag
+        
         r = -1/self.nk * np.einsum("b,ba,kbn->na", self.wb, self.bvec, imlnmnn, optimize=True)
         qn = imlnmnn + np.einsum("ba, na->bn", self.bvec, r, optimize=True)[np.newaxis,:,:]
         OmegaD = np.einsum("b, kbn->", self.wb, qn**2, optimize=True)/self.nk
@@ -210,12 +343,29 @@ class Wannierize:
         print("  OmegaOD = {:15.10f}".format(OmegaOD))
 
     def calc_dw(self):
+        """Compute the gradient matrix G for steepest-descent update.
+        
+        Calculates the anti-Hermitian matrix dW(k) = G(k) following R1_Eq.(52),
+        used to update the unitary rotations in the direction of decreasing spread.
+        Reuses cached mnn, imlnmnn, r from calc_omega if available.
+        
+        Returns
+        -------
+        ndarray, shape (nk, num_wann, num_wann)
+            Gradient matrices dW(k), anti-Hermitian at each k-point.
         """
-        calculate G in R1_Eq.(52)
-        """
-        mnn = np.einsum("kbnn->kbn", self.mmn, optimize=True)
-        imlnmnn = np.log(mnn).imag
-        r = -1/self.nk * np.einsum("b,ba,kbn->na", self.wb, self.bvec, imlnmnn, optimize=True)
+        self.log.debug("calc_dw: computing gradient matrices")
+        # Reuse cached values if available (set by calc_omega)
+        if hasattr(self, '_cached_mnn') and hasattr(self, '_cached_imlnmnn') and hasattr(self, '_cached_r'):
+            mnn = self._cached_mnn
+            imlnmnn = self._cached_imlnmnn
+            r = self._cached_r
+        else:
+            mnn = np.einsum("kbnn->kbn", self.mmn, optimize=True)
+            self._assert_nonzero_mnn(mnn, "calc_dw")
+            imlnmnn = np.log(mnn).imag
+            r = -1/self.nk * np.einsum("b,ba,kbn->na", self.wb, self.bvec, imlnmnn, optimize=True)
+        
         Rmn = np.einsum("kbmn,kbn->kbmn", self.mmn, np.conj(mnn), optimize=True)  # R1_Eq.(45)
         qn = imlnmnn + np.einsum("ba, na->bn", self.bvec, r, optimize=True)[np.newaxis,:,:] # R1_Eq.(47)
         T = np.einsum("kbmn, kbn->kbmn", self.mmn, qn/mnn, optimize=True)  # R1_Eq.(48,51)
@@ -225,48 +375,104 @@ class Wannierize:
         dw = 4/self.nk * np.einsum("b,kbmn->kmn", self.wb, AR - ST, optimize=True)  # R1_Eq.(52)
         return dw
 
+    def _assert_nonzero_mnn(self, mnn, context):
+        """Validate that diagonal overlaps are nonzero before logarithm.
+        
+        Parameters
+        ----------
+        mnn : ndarray
+            Diagonal overlap elements M^(k,b)_nn.
+        context : str
+            Caller name for error messages.
+        
+        Raises
+        ------
+        ValueError
+            If any element of mnn is exactly zero.
+        """
+        self.log.debug(f"_assert_nonzero_mnn: checking {context}, mnn.shape={mnn.shape}")
+        if np.any(mnn == 0):
+            count = np.count_nonzero(mnn == 0)
+            self.log.error(f"{context}: mnn contains {count} zero elements")
+            raise ValueError("{}: mnn contains {} zero elements; log undefined".format(context, count))
+
     def calc_expdw(self, dw):
+        """Compute matrix exponential exp(dW) via eigendecomposition.
+        
+        Since dW is anti-Hermitian, i*dW is Hermitian and can be diagonalized with real eigenvalues.
+        Then exp(dW) = V exp(-i*lambda) V^dagger.
+        
+        Parameters
+        ----------
+        dw : ndarray, shape (nk, num_wann, num_wann)
+            Anti-Hermitian gradient matrices.
+        
+        Returns
+        -------
+        ndarray, shape (nk, num_wann, num_wann)
+            Unitary matrices exp(dW(k)).
         """
-        calculate exp(dW) by diagonalizing i*dW  (i*dW is hermite)
-        """
-        expdw = np.zeros_like(dw)
+        # Vectorized eigendecomposition for all k-points
+        e = np.empty((self.nk, self.num_wann), dtype=float)
+        v = np.empty((self.nk, self.num_wann, self.num_wann), dtype=complex)
         for k in range(self.nk):
-            e, v = scipy.linalg.eigh(1j*dw[k,:,:])
-            #idw = np.einsum("ab,b,cb->ac", v, e, np.conj(v), optimize=True)
-            #assert np.allclose(idw, 1j*dw[:,:,k], atol=1e-5), np.sum(np.abs(idw - 1j*dw[:,:,k]))/np.sum(np.abs(idw))
-            expdw[k,:,:] = np.einsum("ab,b,cb->ac", v, np.exp(-1j*e), np.conj(v), optimize=True)
+            e[k], v[k] = scipy.linalg.eigh(1j*dw[k,:,:])
+        # Vectorized matrix multiplication: V @ diag(exp(-i*lambda)) @ V^H
+        exp_e = np.exp(-1j * e)  # (nk, num_wann)
+        expdw = np.einsum("kab,kb,kcb->kac", v, exp_e, np.conj(v), optimize=True)
         return expdw
 
     def update_mmn(self, dw, omega):
+        """Update unitary rotations and overlaps using line search for optimal step size.
+        
+        Uses Brent's method for robust 1D minimization to find optimal mixing parameter alpha.
+        Evaluates Omega(alpha) and finds the minimum with adaptive sampling.
+        
+        Parameters
+        ----------
+        dw : ndarray, shape (nk, num_wann, num_wann)
+            Gradient matrices dW(k).
+        omega : float
+            Current total spread (at alpha=0).
+        
+        Returns
+        -------
+        float
+            New total spread after optimal rotation.
         """
-        calculate optimal alpha and update self.Umat (U^(k)) and self.mmn (Mmn)
-        return omega
-        """
-        Umat1 = np.einsum("kmn, knl->kml", self.Umat, self.calc_expdw(dw), optimize=True)  # R1_Eq.(60)
-        mmn1 = self.update_Mmn_by_Umat(self.mmn1, Umat1)
-        omega1 = self.calc_omega(mmn1)
-
-        Umat2 = np.einsum("kmn, knl->kml", self.Umat, self.calc_expdw(dw/2), optimize=True)  # R1_Eq.(60)
-        mmn2 = self.update_Mmn_by_Umat(self.mmn1, Umat2)
-        omega2 = self.calc_omega(mmn2)
-
-        # get optimum alpha from omega(alpha=0), omega(alpha=1/2)=omega2, omega(alpha=1)=omega1
-        if 2*omega + 2*omega1 - 4*omega2 < 0:
-            alpha = 0.01 if omega < omega1 else 1.0
-        else:
-            alpha = -(4*omega2-omega1-3*omega) /2/ (2*omega+2*omega1-4*omega2)
-            alpha = min(1, alpha)
-            alpha = max(0.01, alpha)
-        #print("{:10.5f} {:10.5f} {:10.5f} {:10.5f}".format(omega, omega2, omega1, alpha))
-
-        self.Umat = np.einsum("kmn, knl->kml", self.Umat, self.calc_expdw(alpha*dw), optimize=True)  # R1_Eq.(60)
-        #if self.lsite_sym:
-        #    self.Umat = self.amn.Umat_symmetrize(self.Umat, self.Umat_opt)
+        self.log.debug("update_mmn: computing line search with Brent's method")
+        
+        # Define objective function for line search
+        def omega_at_alpha(alpha):
+            """Compute Omega for given alpha step size."""
+            expdw_alpha = self.calc_expdw(alpha * dw)
+            Umat_alpha = np.einsum("kmn, knl->kml", self.Umat, expdw_alpha, optimize=True)
+            mmn_alpha = self.update_Mmn_by_Umat(self.mmn1, Umat_alpha)
+            return self.calc_omega(mmn_alpha)
+        
+        # Use Brent's method for 1D minimization in range [0, 1]
+        # bracket=(0, 1) ensures search within [0, 1]
+        result = scipy.optimize.minimize_scalar(
+            omega_at_alpha,
+            bounds=(0.01, 1.0),
+            method='bounded',
+            options={'xatol': 1e-4}  # Tolerance for alpha convergence
+        )
+        
+        alpha = result.x
+        omega_new = result.fun
+        self.log.debug(f"update_mmn: optimal alpha={alpha:.4f}, omega={omega_new:.8f} (nfev={result.nfev})")
+        
+        # Update with optimal alpha
+        expdw_opt = self.calc_expdw(alpha * dw)
+        self.Umat = np.einsum("kmn, knl->kml", self.Umat, expdw_opt, optimize=True)
         self.mmn = self.update_Mmn_by_Umat(self.mmn1, self.Umat)
         omega = self.calc_omega(self.mmn)
+        
         return omega
 
     def dis_window(self):
+        """Define energy windows for disentanglement."""
         # array with self.nband size
         self.index_froz = (self.eig.eig > self.win.dis_froz_min) & (self.eig.eig < self.win.dis_froz_max)
         self.index_win = (self.eig.eig > self.win.dis_win_min) & (self.eig.eig < self.win.dis_win_max)
@@ -274,11 +480,69 @@ class Wannierize:
         self.len_nfroz = np.array([ np.sum(self.index_nfroz[k,:]) for k in range(self.nk) ])
         self.ndimwin = np.array([ np.sum(self.index_win[k,:]) for k in range(self.nk) ])
         self.ndimfroz = np.array([ np.sum(self.index_froz[k,:]) for k in range(self.nk) ])
+        self.log.debug(f"dis_window: ndimwin min={np.min(self.ndimwin)}, max={np.max(self.ndimwin)}, ndimfroz min={np.min(self.ndimfroz)}, max={np.max(self.ndimfroz)}")
+
+    def dis_window_projectability(self, dis_proj_max = None, dis_proj_min = None):
+        """Define disentanglement windows using projectability from Amn overlaps.
+
+        The projectability of each Bloch state is p_mk = sum_n |<psi_mk|g_n>|^2.
+        Bands with high projectability are frozen; the outer window collects the
+        best-projected bands until a reasonable buffer over num_wann is reached.
+        
+        If dis_proj_max is not specified, it is automatically determined by:
+        - Sorting all bands by projectability across all k-points
+        - Freezing approximately 70-80% of num_wann bands with highest projectability
+        - Leaving room for disentanglement to optimize the remaining bands
+        """
+        proj = self.projectability
+        if dis_proj_max is not None and 0 <= dis_proj_max <= 1:
+            self.log.info(f"Using user-specified dis_proj_max = {dis_proj_max:.4f}")
+        else:
+            if hasattr(self.win, "dis_proj_max"):
+                dis_proj_max = self.win.dis_proj_max
+                self.log.info(f"Using win-specified dis_proj_max = {dis_proj_max:.4f}")
+            else:
+                # Smart determination: freeze ~75% of num_wann to leave room for disentanglement
+                # This balances stability (frozen bands) with flexibility (optimizable bands)
+                proj_flat = proj.flatten()
+                proj_sorted = np.sort(proj_flat)[::-1]  # descending order
+                num_frozen_target = int(0.75 * self.num_wann * self.nk)
+                idx_cutoff = min(num_frozen_target, len(proj_sorted) - 1)
+                dis_proj_max = proj_sorted[idx_cutoff]
+                # Add small margin to avoid floating point issues
+                dis_proj_max = max(0.90, dis_proj_max - 0.01)
+                self.log.info(f"Auto-determined dis_proj_max = {dis_proj_max:.4f} (targeting ~75% of num_wann as frozen)")
+        
+        if dis_proj_min is not None and 0 <= dis_proj_min <= 1:
+            self.log.info(f"Using user-specified dis_proj_min = {dis_proj_min:.4f}")
+        else:
+            if hasattr(self.win, "dis_proj_min"):
+                dis_proj_min = self.win.dis_proj_min
+                self.log.info(f"Using win-specified dis_proj_min = {dis_proj_min:.4f}")
+            else:
+                # Smart determination: include enough bands for disentanglement
+                # Typically want num_wann + buffer bands in the window
+                buffer = min(self.num_wann // 2, self.num_bands - self.num_wann)
+                proj_flat = proj.flatten()
+                proj_sorted = np.sort(proj_flat)[::-1]  # descending order
+                idx_cutoff = min(self.num_wann + buffer * self.nk, len(proj_sorted) - 1)
+                dis_proj_min = proj_sorted[idx_cutoff]
+                # Ensure minimum threshold is reasonable
+                dis_proj_min = max(0.05, min(0.25, dis_proj_min - 0.01))
+                self.log.info(f"Auto-determined dis_proj_min = {dis_proj_min:.4f} (buffer={buffer} bands per k-point)")
+
+        self.index_froz = dis_proj_max <= self.projectability
+        self.index_win = dis_proj_min <= self.projectability
+        self.index_nfroz = self.index_win & (~self.index_froz)
+        self.len_nfroz = np.array([np.sum(self.index_nfroz[k, :]) for k in range(self.nk)])
+        self.ndimwin = np.array([np.sum(self.index_win[k, :]) for k in range(self.nk)])
+        self.ndimfroz = np.array([np.sum(self.index_froz[k, :]) for k in range(self.nk)])
+        self.log.info(f"num_inner (min, max, mean): {np.min(self.ndimfroz)}, {np.max(self.ndimfroz)}, {np.mean(self.ndimfroz)}")
+        self.log.info(f"num_outer (min, max, mean): {np.min(self.ndimwin)}, {np.max(self.ndimwin)}, {np.mean(self.ndimwin)}")
 
     def dis_project(self):
-        """
-        calculate self.Umat_opt and update mmn0U from amn file
-        """
+        """Calculate self.Umat_opt and update mmn0 from amn file."""
+        self.log.debug("dis_project: starting projection")
         assert hasattr(self, "amn"), "file_amn is not specified"
         self.Umat_opt = self.amn.Umat(index_win = self.index_win)  # Umat_opt[:num_bands, :num_wann, :nk]
 
@@ -497,13 +761,34 @@ def main(argv=None, for_cli=False):
     )
 
     parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set logging level (default: INFO)"
+    )
+
+    parser.add_argument(
+        "--optimize-memory",
+        action="store_true",
+        dest="optimize_memory_usage",
+        help="Prioritize memory efficiency over speed (default: optimize for speed)"
+    )
+
+    parser.add_argument(
+        "-P", "--projectability-disentangle",
+        action="store_true",
+        help="Use AMN projectability to define disentanglement windows instead of energy windows"
+    )
+
+    parser.add_argument(
         "prefix",
         help="Prefix name of input/output files"
     )
 
     args = parser.parse_args(argv)
 
-    wann = Wannierize(prefix=args.prefix, lsym=args.symmetry, lsite_sym=args.site_symmetry, prec=args.high_precision)
+    wann = Wannierize(prefix=args.prefix, lsym=args.symmetry, lsite_sym=args.site_symmetry, prec=args.high_precision, optimize_memory_usage=args.optimize_memory_usage, projectability_disentangle=args.projectability_disentangle, log_level=args.log_level)
     wann.run()
 
 


### PR DESCRIPTION
## Summary

- Adds `-P/--projectability-disentangle` flag to `wannierize.py`
- Computes projectability from AMN overlaps: `sum_n |<psi_mk|g_n>|^2`
- Automatically defines disentanglement windows based on projectability (replaces energy windows)
- Adds validation checks: raises error if projectability contains NaN, Inf, or negative values

## Changes

Single file changed: `src/symwannier/wannierize.py`
- `__init__`: add `projectability_disentangle=False` parameter
- New method `dis_window_projectability()`: determine dis_win/froz windows from projectability
- `run()`: dispatch to `dis_window_projectability()` when `-P` is set
- CLI: add `-P/--projectability-disentangle` argument

## Notes

This is a minimal re-submission of #7, containing only the core wannierize.py changes.
The Fe regression tests (requiring large input files) are retained on `feature/projectability-disentanglement` for future TDD work.