### PR TITLE
Apply projectability sign correction and validation

### DIFF
--- a/src/pw2wannier90/qe7.4.1/pw2wannier90.f90
+++ b/src/pw2wannier90/qe7.4.1/pw2wannier90.f90
@@ -3754,6 +3754,7 @@ SUBROUTINE compute_mmn_ibz
       USE constants,       ONLY : tpi
       USE wannier,         ONLY : n_wannier, l_w, mr_w, xaxis, zaxis, center_w, &
                                   spin_eig, spin_qaxis
+      USE atproj,          ONLY : atom_proj, atom_proj_ext
       USE symm_base,       ONLY : d1, d2, d3, nsym
       !
       COMPLEX(DP), INTENT(OUT) :: rotmat(n_wannier, n_wannier, nsym2)
@@ -3799,7 +3800,7 @@ SUBROUTINE compute_mmn_ibz
       REAL(DP)              :: dvec(3,32), dvec_in(3,32), dwgt(32), dylm1(32), dylm2(32)
       COMPLEX(DP)           :: spin1(2), spin2(2), u_spin(2,2)
       INTEGER, ALLOCATABLE  :: ip2iw(:), iw2ip(:), ips2p(:,:)
-      REAL(DP), ALLOCATABLE :: vaxis(:,:,:)
+      REAL(DP), ALLOCATABLE :: vaxis(:,:,:), proj_sign(:)
       logical, ALLOCATABLE  :: lfound(:)
       COMPLEX(DP), ALLOCATABLE :: check_mat(:,:)
       INTEGER               :: l, m1, m2
@@ -3871,6 +3872,17 @@ SUBROUTINE compute_mmn_ibz
       !
       allocate( vaxis(3,3,n_wannier), stat=ierr)
       IF (ierr /= 0) CALL errore('pw2wannier90', 'Error allocating vaxis', 1)
+      allocate( proj_sign(n_wannier), stat=ierr)
+      IF (ierr /= 0) CALL errore('pw2wannier90', 'Error allocating proj_sign', 1)
+      proj_sign = 1.0_DP
+      IF (atom_proj .AND. (.NOT. atom_proj_ext)) THEN
+         DO iw = 1, n_wannier
+            ! Keep ordinary atom_proj AMN unchanged and absorb the
+            ! phase-convention mismatch only in symmetry rotmat.
+            IF (l_w(iw) == 1 .AND. mr_w(iw) == 1) proj_sign(iw) = -1.0_DP
+            IF (l_w(iw) == 2 .AND. (mr_w(iw) == 2 .OR. mr_w(iw) == 3)) proj_sign(iw) = -1.0_DP
+         END DO
+      END IF
       rotmat=0.0d0
       do iw=1,n_wannier
          call set_u_matrix (xaxis(:,iw),zaxis(:,iw),vaxis(:,:,iw))
@@ -3907,7 +3919,17 @@ SUBROUTINE compute_mmn_ibz
             end do
          end do
       end do
+      IF (atom_proj .AND. (.NOT. atom_proj_ext)) THEN
+         DO isym = 1, nsym2
+            DO iw = 1, n_wannier
+               DO jw = 1, n_wannier
+                  rotmat(iw,jw,isym) = proj_sign(iw) * rotmat(iw,jw,isym) * proj_sign(jw)
+               END DO
+            END DO
+         END DO
+      END IF
       deallocate(vaxis)
+      deallocate(proj_sign)
       deallocate(ips2p, lfound, iw2ip, ip2iw)
       allocate(check_mat(n_wannier, n_wannier), stat=ierr)
       IF (ierr /= 0) CALL errore('pw2wannier90', 'Error allocating check_mat', 1)

--- a/src/symwannier/wannierize.py
+++ b/src/symwannier/wannierize.py
@@ -107,7 +107,22 @@ class Wannierize:
         self.eig = Eig(prefix+"." + ext + "eig", sym=self.sym, log=self.log)
         self.log.debug(f"Loaded Amn: shape={self.amn.amn.shape}, Eig: shape={self.eig.eig.shape}")
         # Projectability p_mk = sum_n |<psi_mk|g_n>|^2 for optional disentanglement mode
-        self.projectability = np.einsum("knm,knm->kn", self.amn.amn, np.conj(self.amn.amn), optimize=True).real
+        self.projectability = np.einsum(
+            "knm,knm->kn", self.amn.amn, np.conj(self.amn.amn), optimize=True
+        ).real
+        is_finite = np.isfinite(self.projectability)
+        num_nan = np.isnan(self.projectability).sum()
+        num_inf = np.isinf(self.projectability).sum()
+        num_neg = (self.projectability < 0).sum()
+        self.log.info(
+            "projectability stats: "
+            f"min={np.min(self.projectability):.6e}, max={np.max(self.projectability):.6e}, "
+            f"nan={num_nan}, inf={num_inf}, neg={num_neg}"
+        )
+        if not is_finite.all():
+            raise ValueError("projectability contains NaN or inf")
+        if num_neg != 0:
+            raise ValueError("projectability contains negative values")
         self._validate_inputs()
         self.Umat_opt = None
 


### PR DESCRIPTION
## Summary
- Apply `proj_sign` to symmetry rotation matrices for ordinary `atom_proj` projectors.
- Add validation and logging for AMN-derived projectability in `wannierize.py`.
- Keep this PR minimal: no large Fe SW+PD regression inputs or heavy test updates are included.

## Tests
- `pytest` on `fix/minimal-proj-sign`: 11 passed in 13.96s
- `pytest` on original `feature/projectability-disentanglement`: 11 passed in 14.22s